### PR TITLE
docs: name one recommended way to read consent status per platform

### DIFF
--- a/.changeset/single-consent-read-api-docs.md
+++ b/.changeset/single-consent-read-api-docs.md
@@ -1,0 +1,17 @@
+---
+"@cookieyes/core": patch
+"@cookieyes/react": patch
+"@cookieyes/nextjs": patch
+---
+
+Document one recommended way to read consent per platform — `useConsent()`
+for React, `consentStore.subscribe` for core/non-React — and move the other
+seven near-equivalent APIs into a clearly labeled "Low-level / advanced API"
+section in each README, each documented with the specific situation it's for.
+
+Adds a shared decision tree (`docs/which-api-should-i-use.md`) referenced by
+every package's README instead of being copy-pasted, plus short in-editor
+JSDoc pointers on the low-level exports toward the recommended primary API.
+
+No behavior change — all existing APIs continue to work exactly as before.
+This is a documentation and guidance change only.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Open-source, developer-first cookie consent SDK. The same compliance engine that
 
 All business logic lives in `@cookieyes/core`. Framework adapters are thin wrappers — no logic, only wiring.
 
+**Not sure which API reads consent status in your case?** See the
+[decision tree](./docs/which-api-should-i-use.md) — there's one recommended
+path per platform; everything else is a documented low-level option for a
+specific edge case.
+
 ## Quick start
 
 You configure the SDK once with a small builder, then drop in the banner and

--- a/docs/which-api-should-i-use.md
+++ b/docs/which-api-should-i-use.md
@@ -1,0 +1,34 @@
+# Which API should I use to read consent?
+
+There is one recommended way to read consent state per platform. Everything
+else is a legitimate but low-level option for a specific edge case — you
+don't need it unless the tree below sends you there.
+
+```
+Are you inside a React component?
+├─ Yes → useConsent()
+│         Need to gate one thing without re-rendering on every category?
+│         → useConsentCategory(category) instead (low-level)
+│
+├─ No, but I'm in a Next.js Server Component / route handler
+│         (no live runtime, no React hooks available)
+│         → parseCookie() from @cookieyes/core (low-level, reads the raw
+│           cookie string — see that package's README)
+│
+└─ No, plain JS / another framework
+          → consentStore.subscribe(listener)
+          Need to change consent, not just read it?
+          → consentStore.getState() actions (saveConsents, setConsent, ...),
+            or useConsentActions() in React
+          Need to act only on *saved* changes, not every transient update?
+          → subscribeToConsentChanges (low-level)
+```
+
+That's it for ~95% of use cases. The full low-level surface — `useConsentRuntime()`,
+`getCookieYes()`, `onConsentReady`, `onConsentUpdate`, `subscribeToConsentChanges` —
+is documented in each package's README under "Low-level / advanced API," each
+with the specific situation it's for.
+
+This file is the single source of truth for this decision tree — every
+package's README links here rather than repeating it, so it can't drift out
+of sync between packages.

--- a/sdk/cli/README.md
+++ b/sdk/cli/README.md
@@ -4,6 +4,9 @@ Scaffolder for the [CookieYes Consent SDK](https://github.com/cookieyes/cookieye
 detects your framework and package manager, installs the right `@cookieyes/*` packages,
 and wires up the provider and banner for you.
 
+Once scaffolded, see the [decision tree](../../docs/which-api-should-i-use.md)
+for which API to use to read consent status in your code.
+
 ## Usage
 
 Run it in an existing project — no install required:

--- a/sdk/core/README.md
+++ b/sdk/core/README.md
@@ -11,6 +11,13 @@ yarn add @cookieyes/core
 bun add @cookieyes/core
 ```
 
+## Which API should I use?
+
+**`consentStore.subscribe` is the recommended way to read consent outside
+React.** See the [shared decision tree](../../docs/which-api-should-i-use.md)
+if you're not sure which API applies to your situation — core also exposes a
+handful of lower-level options (below) for specific edge cases.
+
 ## Usage
 
 The recommended entry point is `getOrCreateConsentRuntime()`. It returns a
@@ -26,7 +33,9 @@ const { consentManager, consentStore } = getOrCreateConsentRuntime({
   colorScheme: "system",                    // "light" | "dark" | "system"
 });
 
-// React to every saved state change
+// consentStore.subscribe fires on every state change — category saves,
+// transient preference-dialog toggles, and the dialog opening/closing.
+// That's the right level for "should this script run right now?" checks:
 const unsubscribe = consentStore.subscribe((state) => {
   if (state.has("analytics")) {
     // load analytics scripts (gtag, Mixpanel, …)
@@ -35,14 +44,6 @@ const unsubscribe = consentStore.subscribe((state) => {
     // load ad scripts (Meta Pixel, Google Ads, …)
   }
 });
-
-// React only to saved preference changes (not transient UI toggles)
-consentStore
-  .getState()
-  .subscribeToConsentChanges(({ allowedCategories, deniedCategories }) => {
-    console.log("Allowed:", allowedCategories);
-    console.log("Denied:", deniedCategories);
-  });
 
 // Imperative actions
 consentStore.getState().has("analytics");           // → boolean
@@ -96,28 +97,30 @@ Returns `{ consentManager, consentStore }` (a singleton — call
 | `i18n` | `I18nConfig` | Translation messages / locale. |
 | `networkBlocker` | `NetworkBlockerConfig` | Block network requests by category. |
 | `reloadOnRevoke` | `boolean` | Reload the page when consent is revoked. |
-| `onConsentReady` / `onConsentUpdate` | `(state) => void` | Lifecycle callbacks. |
+| `onConsentReady` / `onConsentUpdate` | `(state) => void` | Low-level lifecycle callbacks — see below. |
 
 **`consentStore`** — `subscribe(listener)` and `getState()`. State
 (`ConsentStoreState`) includes `consentId`, `hasActed`, `categories`,
 `regulation`, `lastRenewed`, `activeUI`, plus the methods `has()`,
-`saveConsents()`, `setConsent()`, and `subscribeToConsentChanges()`.
-
-### `createConsentManager(config)` (low-level)
-
-The underlying manager, if you want to bypass the store. Returns a
-`ConsentManager` with:
-
-- **State**: `consentId`, `hasActed`, `categories`, `regulation`, `lastRenewed`, `isPreferencesOpen`
-- **Methods**: `acceptAll()`, `rejectAll()`, `acceptSelected(cats)`, `updateCategory(cat, val)`, `savePreferences()`, `resetConsent()`, `showPreferences()`, `hidePreferences()`, `subscribe(fn)`, `registerScript(entry)`
-
-`config` (`ConsentConfig`) accepts: `regulation`, `colorScheme`, `theme`,
-`apiUrl`, `apiKey`, `backend`, `reloadOnRevoke`, `onConsentReady`,
-`onConsentUpdate`.
+`saveConsents()`, `setConsent()`, and the low-level `subscribeToConsentChanges()`
+(below).
 
 > The applicable regulation comes from your configuration
 > (`overrides.regulation` / `config.regulation`) and defaults to `"DEFAULT"`.
 > The core engine does not perform IP-based geo-detection.
+
+## Low-level / advanced API
+
+You shouldn't need these for a typical integration — each exists for a
+specific narrower situation than `consentStore.subscribe`:
+
+| API | Use when |
+|---|---|
+| `subscribeToConsentChanges(listener)` (on `consentStore.getState()`) | You only care about *saved* consent decisions (accept/reject/save), not every transient toggle or dialog open/close that `subscribe` also reports. |
+| `onConsentReady` (config option) | You need a one-time callback right after the initial state is known — e.g. conditionally loading analytics on first load — rather than an ongoing subscription. |
+| `onConsentUpdate` (config option) | Like `subscribeToConsentChanges`, scoped to saved changes only, but registered once at config time instead of dynamically after mount. Prefer `subscribeToConsentChanges` unless you specifically need a config-time callback. |
+| `createConsentManager(config)` | Bypasses `consentStore` entirely for direct access to the manager: `acceptAll()`, `rejectAll()`, `acceptSelected(cats)`, `updateCategory(cat, val)`, `savePreferences()`, `resetConsent()`, `showPreferences()`, `hidePreferences()`, `subscribe(fn)`, `registerScript(entry)`. `config` (`ConsentConfig`) accepts `regulation`, `colorScheme`, `theme`, `apiUrl`, `apiKey`, `backend`, `reloadOnRevoke`, `onConsentReady`, `onConsentUpdate`. |
+| `parseCookie` / `serializeCookie` | Reading or writing the raw `cookieyes-consent` cookie directly — e.g. in a Next.js Server Component or route handler, where no live runtime or React hooks are available. |
 
 ## Consent categories
 

--- a/sdk/core/src/types.ts
+++ b/sdk/core/src/types.ts
@@ -143,7 +143,9 @@ export type ConsentRuntimeOptions = {
   theme?: ThemeConfig | undefined;
   networkBlocker?: NetworkBlockerConfig | undefined;
   reloadOnRevoke?: boolean | undefined;
+  /** Low-level: fires once, after the runtime's initial state is known (e.g. to conditionally load analytics on first load). For ongoing updates, use `consentStore.subscribeToConsentChanges` instead. */
   onConsentReady?: ((state: ConsentSnapshot) => void) | undefined;
+  /** Low-level: fires on every saved consent change, for the lifetime of this config. If you need to subscribe/unsubscribe dynamically after mount, use `consentStore.getState().subscribeToConsentChanges` instead. */
   onConsentUpdate?: ((state: ConsentSnapshot) => void) | undefined;
 };
 
@@ -160,9 +162,16 @@ export type ConsentStoreState = ConsentSnapshot & {
   has: (category: ConsentCategory) => boolean;
   saveConsents: (target: "all" | "necessary" | ConsentCategory[]) => Promise<void>;
   setConsent: (category: ConsentCategory, value: boolean) => void;
+  /** Low-level: fires only on *saved* preference changes, not transient UI toggles — see `ConsentStore.subscribe` for the recommended, general-purpose subscription. */
   subscribeToConsentChanges: (listener: (payload: ConsentChangePayload) => void) => () => void;
 };
 
+/**
+ * The recommended way to read consent state outside React. `subscribe` fires
+ * on every state change (including transient UI toggles, e.g. a checkbox
+ * flip before saving); for saved-changes-only, see
+ * `ConsentStoreState.subscribeToConsentChanges`.
+ */
 export type ConsentStore = {
   subscribe: (listener: (state: ConsentStoreState) => void) => () => void;
   getState: () => ConsentStoreState;

--- a/sdk/nextjs/README.md
+++ b/sdk/nextjs/README.md
@@ -15,6 +15,16 @@ bun add @cookieyes/nextjs
 
 **Peer dependencies:** Next.js ≥ 14, React ≥ 18, React DOM ≥ 18
 
+## Which API should I use?
+
+This package re-exports `@cookieyes/react` verbatim, so the same guidance
+applies: **`useConsent()`** in client components, and for Server Components
+or route handlers (no React hooks available), read the raw cookie with
+`parseCookie` from `@cookieyes/core`. See the
+[shared decision tree](../../docs/which-api-should-i-use.md) and
+[`@cookieyes/react`'s Hooks section](../react/README.md#hooks) for the full
+low-level surface.
+
 ## Setup (App Router)
 
 Create a client component that configures the runtime and renders the consent

--- a/sdk/react/README.md
+++ b/sdk/react/README.md
@@ -13,6 +13,13 @@ bun add @cookieyes/react
 
 **Peer dependencies:** React ≥ 18, React DOM ≥ 18
 
+## Which API should I use?
+
+**`useConsent()` is the recommended way to read consent in React.** See the
+[shared decision tree](../../docs/which-api-should-i-use.md) if you're not
+sure which API applies to your situation — this package also exposes a
+handful of lower-level hooks (see [Hooks](#hooks)) for specific edge cases.
+
 ## Quick start
 
 Configure the runtime once with `createCookieYes()`, then render the preset
@@ -65,7 +72,7 @@ Chain configuration methods and finish with `.mount()`. `.mode()` is required;
 | `.apiKey(key)` | Optional auth key. |
 | `.blockNetwork(config)` | Block network requests until consent. |
 | `.reloadOnRevoke(true)` | Reload the page when consent is revoked. |
-| `.onConsentReady(fn)` / `.onConsentUpdate(fn)` | Lifecycle callbacks. |
+| `.onConsentReady(fn)` / `.onConsentUpdate(fn)` | Low-level lifecycle callbacks — see [Hooks](#hooks). |
 | `.mount()` | Build and register the runtime. |
 
 ## Components
@@ -129,24 +136,45 @@ major-version bump and a regression test:
 
 ## Hooks
 
+**Read consent state:**
+
 ```tsx
 const snapshot = useConsent();
 // { consentId, hasActed, categories, regulation, lastRenewed, isPreferencesOpen, isOptOutOpen }
+```
 
+**Drive consent (accept/reject/save, open or close dialogs):**
+
+```tsx
 const {
   acceptAll, rejectAll, acceptSelected, save, updateCategory, reset,
   showPreferences, hidePreferences, showOptOut, hideOptOut,
 } = useConsentActions();
-
-const analyticsAllowed = useConsentCategory("analytics"); // boolean
-const regulation = useRegulation();                       // "GDPR" | "CCPA" | "DEFAULT"
-const t = useTranslations();                              // active TranslationMap
-const bannerVisible = useBannerVisibility();              // boolean
-const prefsOpen = usePreferencesOpen();                   // boolean
-const optOutOpen = useOptOutOpen();                       // boolean
 ```
 
-`useConsentRuntime()` returns the underlying runtime if you need direct access.
+**Other hooks** (each reads something `useConsent()` doesn't cover, so these
+aren't alternatives to it):
+
+```tsx
+const regulation = useRegulation();          // "GDPR" | "CCPA" | "DEFAULT"
+const t = useTranslations();                 // active TranslationMap
+const bannerVisible = useBannerVisibility();  // boolean
+const prefsOpen = usePreferencesOpen();       // boolean
+const optOutOpen = useOptOutOpen();           // boolean
+```
+
+### Low-level hooks
+
+You shouldn't need these for a typical integration — each exists for a
+narrower situation than `useConsent()` / `useConsentActions()`:
+
+| Hook / callback | Use when |
+|---|---|
+| `useConsentCategory(category)` | You're gating one thing (e.g. an embed) and want to re-render only when *that* category changes, not on every consent update. |
+| `useConsentRuntime()` | You need direct access to the underlying runtime (manager, snapshot getters, script registration) — something neither `useConsent()` nor `useConsentActions()` exposes. |
+| `getCookieYes()` | You need imperative, non-hook access outside a component (event handlers, non-component modules). |
+| `.onConsentReady(fn)` (builder) | A one-time callback right after the initial state is known, rather than an ongoing subscription. |
+| `.onConsentUpdate(fn)` (builder) | Fires on every *saved* change only (not transient toggles), registered once at config time. For a dynamic subscribe/unsubscribe instead, use `useConsentRuntime().manager.subscribe` or core's `consentStore.getState().subscribeToConsentChanges`. |
 
 ## Theming
 

--- a/sdk/react/src/hooks/useConsent.ts
+++ b/sdk/react/src/hooks/useConsent.ts
@@ -8,6 +8,13 @@ import {
   type CookieYesSnapshot,
 } from "../runtime.js";
 
+/**
+ * The recommended way to read consent state in React. Subscribes to every
+ * change and re-renders on any update (accepted/rejected categories, banner
+ * visibility, etc). For a single category with fewer re-renders, see
+ * `useConsentCategory()`; for actions (accept/reject/save), see
+ * `useConsentActions()`.
+ */
 export function useConsent(): CookieYesSnapshot {
   const runtime = _tryGetCookieYes();
   return useSyncExternalStore(

--- a/sdk/react/src/hooks/useConsentActions.ts
+++ b/sdk/react/src/hooks/useConsentActions.ts
@@ -30,6 +30,11 @@ const NOOP_ACTIONS: ConsentActions = {
   hideOptOut: () => undefined,
 };
 
+/**
+ * Imperative actions for driving consent (accept/reject/save/reset, open or
+ * close the preferences dialog). Pair this with `useConsent()` for
+ * reading state — this hook only writes, it does not subscribe to changes.
+ */
 export function useConsentActions(): ConsentActions {
   const runtime = _tryGetCookieYes();
   return useMemo<ConsentActions>(() => {

--- a/sdk/react/src/hooks/useConsentCategory.ts
+++ b/sdk/react/src/hooks/useConsentCategory.ts
@@ -3,6 +3,12 @@
 import type { ConsentCategory } from "@cookieyes/core";
 import { useRuntimeSelector } from "./useRuntimeSelector.js";
 
+/**
+ * Low-level: reads a single category and re-renders only when *that*
+ * category's value changes, not on every consent update — use this instead
+ * of `useConsent()` when you're gating one thing (e.g. an embed) and
+ * want to avoid re-rendering on unrelated category changes.
+ */
 export function useConsentCategory(category: ConsentCategory): boolean {
   return useRuntimeSelector((snap) => snap.categories[category] === true, false);
 }

--- a/sdk/react/src/hooks/useConsentRuntime.ts
+++ b/sdk/react/src/hooks/useConsentRuntime.ts
@@ -2,6 +2,12 @@
 
 import { type CookieYesRuntime, getCookieYes } from "../runtime.js";
 
+/**
+ * Low-level: direct access to the underlying runtime (manager, snapshot
+ * getters, script registration). Most components want `useConsent()`
+ * or `useConsentActions()` instead — reach for this only when you need
+ * something neither of those exposes.
+ */
 export function useConsentRuntime(): CookieYesRuntime {
   return getCookieYes();
 }

--- a/sdk/react/src/runtime.ts
+++ b/sdk/react/src/runtime.ts
@@ -65,7 +65,9 @@ export type Builder = {
   apiKey: (key: string) => Builder;
   blockNetwork: (config: NetworkBlockerConfig) => Builder;
   reloadOnRevoke: (value?: boolean) => Builder;
+  /** Low-level: fires once, after initial state is known. Prefer `useConsent()` for ongoing reads inside a component. */
   onConsentReady: (fn: (state: ConsentSnapshot) => void) => Builder;
+  /** Low-level: fires on every *saved* change only (not transient toggles), registered once here. For dynamic subscribe/unsubscribe, use `useConsentRuntime()`. */
   onConsentUpdate: (fn: (state: ConsentSnapshot) => void) => Builder;
   mount: () => CookieYesRuntime;
 };
@@ -213,6 +215,11 @@ function mountRuntime(cfg: RuntimeConfig): CookieYesRuntime {
   return runtime;
 }
 
+/**
+ * Low-level: imperative, non-hook access to the mounted runtime — for use
+ * outside React components/render (event handlers, non-component modules).
+ * Inside a component, prefer `useConsent()` or `useConsentActions()`.
+ */
 export function getCookieYes(): CookieYesRuntime {
   if (!_instance) {
     throw new Error(

--- a/sdk/translations/README.md
+++ b/sdk/translations/README.md
@@ -3,6 +3,9 @@
 Curated translation catalog for the [CookieYes Consent SDK](https://github.com/cookieyes/cookieyes).
 Each locale is its own sub-path export, so importing one language never bundles the others.
 
+This package only provides locale strings — for which API to use to read
+consent status, see the [shared decision tree](../../docs/which-api-should-i-use.md).
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary

There were nine near-identical ways to check consent state across `core` and `react`, with no guidance on which to pick — a new developer opening the README would see nine options and no obvious starting point.

- Named one primary path per platform: `useConsent()` for React, `consentStore.subscribe` for core/non-React.
- Moved the other 7 paths into a clearly labeled "Low-level / advanced API" section in each README, each documented with the specific situation it's actually for.
- Added `docs/which-api-should-i-use.md` — a single shared decision tree linked from every package's README instead of copy-pasted, so it can't drift out of sync.
- Added short JSDoc comments on the low-level exports pointing back to the primary API, visible on hover in-editor.

No behavior change — every existing API continues to work exactly as before. This is a documentation and guidance change only.

## Related issues

N/A

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] Added a changeset (`pnpm changeset`) for any user-facing change
- [x] Updated docs / README where relevant