### PR TITLE
feat: add cookie-only mode as a clearer name for offline mode

### DIFF
--- a/.changeset/rename-mode-value.md
+++ b/.changeset/rename-mode-value.md
@@ -1,0 +1,23 @@
+---
+"@cookieyes/core": minor
+"@cookieyes/react": minor
+"@cookieyes/cli": minor
+---
+
+Add `mode: "cookie-only"` as the clearer, self-explanatory replacement for `mode: "offline"`.
+
+Both values behave identically today. `"offline"` is now marked `@deprecated` in
+TypeScript (shows as struck-through in editor autocomplete) and logs a one-time,
+per-page-load console warning pointing to `"cookie-only"`. `"offline"` will be
+removed 3 releases from now; there is no urgency to migrate today, but new
+code and docs should use `"cookie-only"`.
+
+The CLI (`@cookieyes/cli init`) now scaffolds new projects with `"cookie-only"`
+by default.
+
+```diff
+ createCookieYes()
+-  .mode("offline")
++  .mode("cookie-only")
+   .mount();
+```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import {
 } from "@cookieyes/react";
 
 createCookieYes()
-  .mode("offline")        // "offline" (cookie-only) | "self-hosted"
+  .mode("cookie-only")    // "cookie-only" | "self-hosted"
   .regulation("GDPR")     // "GDPR" | "CCPA"
   .colorScheme("system")  // "light" | "dark" | "system"
   .mount();

--- a/sdk/cli/src/__tests__/init.test.ts
+++ b/sdk/cli/src/__tests__/init.test.ts
@@ -82,11 +82,11 @@ beforeEach(() => {
   h.reactProjectPaths.mockReturnValue(REACT_PATHS);
 });
 
-describe("runInit — Next.js (offline, GDPR)", () => {
+describe("runInit — Next.js (cookie-only, GDPR)", () => {
   it("scaffolds the consent-manager and installs the nextjs adapter", async () => {
     h.select
       .mockResolvedValueOnce("nextjs")
-      .mockResolvedValueOnce("offline")
+      .mockResolvedValueOnce("cookie-only")
       .mockResolvedValueOnce("GDPR")
       .mockResolvedValueOnce("light");
     h.multiselect.mockResolvedValueOnce([]);
@@ -156,7 +156,7 @@ describe("runInit — patching existing files", () => {
   it("patches an existing Next.js app-router layout", async () => {
     h.select
       .mockResolvedValueOnce("nextjs")
-      .mockResolvedValueOnce("offline")
+      .mockResolvedValueOnce("cookie-only")
       .mockResolvedValueOnce("GDPR")
       .mockResolvedValueOnce("light");
     h.multiselect.mockResolvedValueOnce([]);
@@ -175,7 +175,7 @@ describe("runInit — patching existing files", () => {
   it("patches an existing Pages-router _app", async () => {
     h.select
       .mockResolvedValueOnce("nextjs")
-      .mockResolvedValueOnce("offline")
+      .mockResolvedValueOnce("cookie-only")
       .mockResolvedValueOnce("GDPR")
       .mockResolvedValueOnce("light");
     h.multiselect.mockResolvedValueOnce([]);
@@ -194,7 +194,7 @@ describe("runInit — patching existing files", () => {
   it("patches an existing React entry and warns when install fails", async () => {
     h.select
       .mockResolvedValueOnce("react")
-      .mockResolvedValueOnce("offline")
+      .mockResolvedValueOnce("cookie-only")
       .mockResolvedValueOnce("GDPR")
       .mockResolvedValueOnce("light");
     h.multiselect.mockResolvedValueOnce([]);
@@ -212,7 +212,7 @@ describe("runInit — patching existing files", () => {
   it("prints a manual step when a Pages-router _app does not exist", async () => {
     h.select
       .mockResolvedValueOnce("nextjs")
-      .mockResolvedValueOnce("offline")
+      .mockResolvedValueOnce("cookie-only")
       .mockResolvedValueOnce("GDPR")
       .mockResolvedValueOnce("light");
     h.multiselect.mockResolvedValueOnce([]);
@@ -229,7 +229,7 @@ describe("runInit — patching existing files", () => {
   it("skips patching when the layout already uses CookieYesRoot", async () => {
     h.select
       .mockResolvedValueOnce("nextjs")
-      .mockResolvedValueOnce("offline")
+      .mockResolvedValueOnce("cookie-only")
       .mockResolvedValueOnce("GDPR")
       .mockResolvedValueOnce("light");
     h.multiselect.mockResolvedValueOnce([]);
@@ -247,7 +247,7 @@ describe("runInit — patching existing files", () => {
   it("warns when the translations install fails", async () => {
     h.select
       .mockResolvedValueOnce("vanilla")
-      .mockResolvedValueOnce("offline")
+      .mockResolvedValueOnce("cookie-only")
       .mockResolvedValueOnce("GDPR")
       .mockResolvedValueOnce("light");
     h.multiselect.mockResolvedValueOnce(["de"]);
@@ -263,7 +263,7 @@ describe("runInit — patching existing files", () => {
   it("skips the React provider/index when they already exist", async () => {
     h.select
       .mockResolvedValueOnce("react")
-      .mockResolvedValueOnce("offline")
+      .mockResolvedValueOnce("cookie-only")
       .mockResolvedValueOnce("GDPR")
       .mockResolvedValueOnce("light");
     h.multiselect.mockResolvedValueOnce([]);
@@ -279,7 +279,7 @@ describe("runInit — patching existing files", () => {
   it("skips the vanilla consent file when it already exists", async () => {
     h.select
       .mockResolvedValueOnce("vanilla")
-      .mockResolvedValueOnce("offline")
+      .mockResolvedValueOnce("cookie-only")
       .mockResolvedValueOnce("GDPR")
       .mockResolvedValueOnce("light");
     h.multiselect.mockResolvedValueOnce([]);

--- a/sdk/cli/src/commands/init.ts
+++ b/sdk/cli/src/commands/init.ts
@@ -25,7 +25,7 @@ import { insertImport, patchNextjsLayout, patchNextjsPagesApp } from "../utils/p
 type Locale = "es" | "fr" | "de";
 
 type OptionInputs = {
-  mode: "self-hosted" | "offline";
+  mode: "self-hosted" | "cookie-only";
   regulation: "GDPR" | "CCPA";
   colorScheme: "light" | "dark";
   backendURL?: string | undefined;
@@ -308,17 +308,21 @@ export async function runInit(): Promise<void> {
   const modeAnswer = await select({
     message: "Backend mode?",
     options: [
-      { value: "offline" as const, label: "Offline", hint: "no backend — cookie-only" },
+      {
+        value: "cookie-only" as const,
+        label: "Cookie-only",
+        hint: "no backend — stored in a browser cookie",
+      },
       { value: "self-hosted" as const, label: "Self-hosted", hint: "sync consent to your backend" },
     ],
-    initialValue: "offline" as const,
+    initialValue: "cookie-only" as const,
   });
 
   if (isCancel(modeAnswer)) {
     cancel("Setup cancelled.");
     process.exit(0);
   }
-  const mode = modeAnswer as "offline" | "self-hosted";
+  const mode = modeAnswer as "cookie-only" | "self-hosted";
 
   // ── Backend URL (only when self-hosted) ────────────────────────────────────
   let backendURL: string | undefined;

--- a/sdk/core/README.md
+++ b/sdk/core/README.md
@@ -21,7 +21,7 @@ process-wide singleton with a `consentStore` (reactive state) and a
 import { getOrCreateConsentRuntime } from "@cookieyes/core";
 
 const { consentManager, consentStore } = getOrCreateConsentRuntime({
-  mode: "offline",                          // "offline" (cookie-only) | "self-hosted"
+  mode: "cookie-only",                      // "cookie-only" | "self-hosted"
   overrides: { regulation: "GDPR" },        // "GDPR" | "CCPA" | "DEFAULT"
   colorScheme: "system",                    // "light" | "dark" | "system"
 });
@@ -75,6 +75,19 @@ getOrCreateConsentRuntime({
 });
 ```
 
+### Deprecated: `mode: "offline"`
+
+`"offline"` was renamed to `"cookie-only"` — same behavior, clearer name. It
+still works today and logs a one-time console warning, and will be removed
+3 releases from now.
+
+```diff
+ getOrCreateConsentRuntime({
+-  mode: "offline",
++  mode: "cookie-only",
+ });
+```
+
 ## API
 
 ### `getOrCreateConsentRuntime(options)`
@@ -86,7 +99,7 @@ Returns `{ consentManager, consentStore }` (a singleton — call
 
 | Option | Type | Notes |
 |--------|------|-------|
-| `mode` | `"offline" \| "self-hosted"` | **Required.** |
+| `mode` | `"cookie-only" \| "self-hosted"` | **Required.** See [Deprecated](#deprecated-mode-offline) for the retired `"offline"` name. |
 | `backendURL` | `string` | Self-hosted: endpoint the payload is POSTed to. |
 | `backend` | `ConsentBackend` | Self-hosted: custom `persist(payload)` adapter. |
 | `apiKey` | `string` | Optional auth key. |

--- a/sdk/core/src/__tests__/deprecations.test.ts
+++ b/sdk/core/src/__tests__/deprecations.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetOfflineModeWarning } from "../deprecations.js";
+import { getOrCreateConsentRuntime, resetConsentRuntime } from "../runtime.js";
+
+function clearCookie(): void {
+  document.cookie = "cookieyes-consent=; max-age=0; path=/";
+}
+
+beforeEach(() => {
+  clearCookie();
+  _resetOfflineModeWarning();
+});
+afterEach(() => {
+  resetConsentRuntime();
+  clearCookie();
+  vi.restoreAllMocks();
+});
+
+describe('mode: "offline" deprecation', () => {
+  it('warns once, on the console, when mode is "offline"', () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    getOrCreateConsentRuntime({ mode: "offline" });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("cookie-only");
+  });
+
+  it("does not warn again for a second runtime creation in the same page load", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    getOrCreateConsentRuntime({ mode: "offline" });
+    resetConsentRuntime();
+    getOrCreateConsentRuntime({ mode: "offline" });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('never warns for mode: "cookie-only"', () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    getOrCreateConsentRuntime({ mode: "cookie-only" });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('"cookie-only" and "offline" produce the same runtime shape', () => {
+    const cookieOnly = getOrCreateConsentRuntime({ mode: "cookie-only" });
+    resetConsentRuntime();
+    const offline = getOrCreateConsentRuntime({ mode: "offline" });
+
+    expect(Object.keys(cookieOnly.consentStore.getState())).toEqual(
+      Object.keys(offline.consentStore.getState()),
+    );
+  });
+});

--- a/sdk/core/src/deprecations.ts
+++ b/sdk/core/src/deprecations.ts
@@ -1,0 +1,23 @@
+let warnedOfflineMode = false;
+
+/**
+ * One-time-per-page-load console warning for `mode: "offline"`.
+ * Both @cookieyes/core and @cookieyes/react call this so the wording and the
+ * "once" behavior stay identical no matter which package reads the setting.
+ */
+export function _warnOfflineModeDeprecated(): void {
+  if (warnedOfflineMode) return;
+  warnedOfflineMode = true;
+  if (typeof console === "undefined") return;
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[cookieyes] mode: "offline" has been renamed to "cookie-only". Both do exactly ' +
+      'the same thing, but "offline" is deprecated and will be removed in 3 releases. ' +
+      'Update to .mode("cookie-only") (or { mode: "cookie-only" }).',
+  );
+}
+
+/** @internal test-only — resets the one-time warning guard between test cases. */
+export function _resetOfflineModeWarning(): void {
+  warnedOfflineMode = false;
+}

--- a/sdk/core/src/index.ts
+++ b/sdk/core/src/index.ts
@@ -1,4 +1,8 @@
 export { generateConsentId, parseCookie, serializeCookie } from "./cookie.js";
+export {
+  _resetOfflineModeWarning,
+  _warnOfflineModeDeprecated,
+} from "./deprecations.js";
 export { defaultTranslations, resolveTranslations } from "./i18n.js";
 export { createConsentManager } from "./manager.js";
 export type {

--- a/sdk/core/src/runtime.ts
+++ b/sdk/core/src/runtime.ts
@@ -1,3 +1,4 @@
+import { _warnOfflineModeDeprecated } from "./deprecations.js";
 import { createConsentManager } from "./manager.js";
 import { installNetworkBlocker } from "./network-blocker.js";
 import type {
@@ -25,6 +26,8 @@ let _runtime: ConsentRuntime | null = null;
 
 export function getOrCreateConsentRuntime(options: ConsentRuntimeOptions): ConsentRuntime {
   if (_runtime) return _runtime;
+
+  if (options.mode === "offline") _warnOfflineModeDeprecated();
 
   const changeListeners = new Set<(payload: ConsentChangePayload) => void>();
   const userOnConsentUpdate = options.onConsentUpdate;

--- a/sdk/core/src/types.ts
+++ b/sdk/core/src/types.ts
@@ -125,7 +125,13 @@ export interface ConsentBackend {
   persist(payload: ConsentPayload): Promise<void> | void;
 }
 
-export type ConsentRuntimeMode = "self-hosted" | "offline";
+/**
+ * @deprecated Use `"cookie-only"` instead — identical behavior, clearer name.
+ * `"offline"` still works but will be removed in a future release.
+ */
+type DeprecatedOfflineMode = "offline";
+
+export type ConsentRuntimeMode = "self-hosted" | "cookie-only" | DeprecatedOfflineMode;
 
 export type ConsentRuntimeOptions = {
   mode: ConsentRuntimeMode;

--- a/sdk/nextjs/README.md
+++ b/sdk/nextjs/README.md
@@ -33,7 +33,7 @@ import {
 } from "@cookieyes/nextjs";
 
 createCookieYes()
-  .mode("offline")        // "offline" (cookie-only) | "self-hosted"
+  .mode("cookie-only")    // "cookie-only" | "self-hosted"
   .regulation("GDPR")     // "GDPR" | "CCPA"
   .colorScheme("system")  // "light" | "dark" | "system"
   .mount();

--- a/sdk/react/README.md
+++ b/sdk/react/README.md
@@ -31,7 +31,7 @@ import {
 } from "@cookieyes/react";
 
 createCookieYes()
-  .mode("offline")        // "offline" (cookie-only) | "self-hosted"
+  .mode("cookie-only")    // "cookie-only" | "self-hosted"
   .regulation("GDPR")     // "GDPR" | "CCPA"
   .colorScheme("system")  // "light" | "dark" | "system"
   .mount();
@@ -56,7 +56,7 @@ Chain configuration methods and finish with `.mount()`. `.mode()` is required;
 
 | Method | Purpose |
 |--------|---------|
-| `.mode("offline" \| "self-hosted")` | **Required.** Cookie-only vs. synced to your backend. |
+| `.mode("cookie-only" \| "self-hosted")` | **Required.** Cookie-only vs. synced to your backend. See [Deprecated](#deprecated-mode-offline) for the retired `"offline"` name. |
 | `.regulation("GDPR" \| "CCPA" \| "DEFAULT")` | Which regulation applies. |
 | `.colorScheme("light" \| "dark" \| "system")` | Theme mode. |
 | `.theme(themeConfig)` | Color / radius / font tokens. |
@@ -67,6 +67,19 @@ Chain configuration methods and finish with `.mount()`. `.mode()` is required;
 | `.reloadOnRevoke(true)` | Reload the page when consent is revoked. |
 | `.onConsentReady(fn)` / `.onConsentUpdate(fn)` | Lifecycle callbacks. |
 | `.mount()` | Build and register the runtime. |
+
+### Deprecated: `mode: "offline"`
+
+`"offline"` was renamed to `"cookie-only"` — same behavior, clearer name. It
+still works today and logs a one-time console warning, and will be removed
+3 releases from now.
+
+```diff
+ createCookieYes()
+-  .mode("offline")
++  .mode("cookie-only")
+   .mount();
+```
 
 ## Components
 
@@ -113,9 +126,9 @@ presets above are built from exactly these primitives.
 `<CookieBanner />` is **server-rendered**: its markup is present in the initial
 HTML (first-byte paint) and on every load, before client JavaScript hydrates the
 interactive parts. It uses fixed positioning, so showing it never shifts page
-layout (no CLS), and it issues **no network request on load** (offline mode makes
-zero requests; self-hosted mode only POSTs to your backend when the user accepts,
-rejects, or saves).
+layout (no CLS), and it issues **no network request on load** (cookie-only mode
+makes zero requests; self-hosted mode only POSTs to your backend when the user
+accepts, rejects, or saves).
 
 The following selectors are a **stable, public contract** — automated tooling and
 your own integrations may rely on them, and they will not change without a
@@ -155,7 +168,7 @@ can also override them in your own stylesheet:
 
 ```tsx
 createCookieYes()
-  .mode("offline")
+  .mode("cookie-only")
   .theme({
     primaryColor: "#6366F1",
     backgroundColor: "#ffffff",

--- a/sdk/react/src/__tests__/deprecations.test.tsx
+++ b/sdk/react/src/__tests__/deprecations.test.tsx
@@ -1,0 +1,33 @@
+import { _resetOfflineModeWarning } from "@cookieyes/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCookieYes, resetCookieYes } from "../runtime.js";
+import { clearCookie, mountCookieOnly } from "./test-utils.js";
+
+beforeEach(() => {
+  clearCookie();
+  _resetOfflineModeWarning();
+});
+afterEach(() => {
+  resetCookieYes();
+  clearCookie();
+  vi.restoreAllMocks();
+});
+
+describe('mode: "offline" deprecation (react)', () => {
+  it('warns once when .mode("offline") is used', () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    createCookieYes().mode("offline").mount();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("cookie-only");
+  });
+
+  it('does not warn for .mode("cookie-only")', () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    mountCookieOnly();
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/sdk/react/src/__tests__/test-utils.tsx
+++ b/sdk/react/src/__tests__/test-utils.tsx
@@ -6,9 +6,18 @@ export function clearCookie(): void {
   document.cookie = "cookieyes-consent=; max-age=0; path=/";
 }
 
-/** Mounts an offline runtime for the given regulation and returns it. */
+/**
+ * Mounts a cookie-only runtime for the given regulation and returns it.
+ * @deprecated call sites kept for coverage still use {@link mountOffline} —
+ * both produce an identical runtime.
+ */
 export function mountOffline(regulation: Regulation = "GDPR"): CookieYesRuntime {
   return createCookieYes().mode("offline").regulation(regulation).mount();
+}
+
+/** Mounts a cookie-only runtime for the given regulation and returns it. */
+export function mountCookieOnly(regulation: Regulation = "GDPR"): CookieYesRuntime {
+  return createCookieYes().mode("cookie-only").regulation(regulation).mount();
 }
 
 /** Standard afterEach: drop the singleton runtime and clear the cookie. */

--- a/sdk/react/src/runtime.ts
+++ b/sdk/react/src/runtime.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import type { NetworkBlockerConfig } from "@cookieyes/core";
 import {
+  _warnOfflineModeDeprecated,
   type ConsentBackend,
   type ConsentCategory,
   type ConsentConfig,
@@ -10,6 +10,7 @@ import {
   createConsentManager,
   type I18nConfig,
   installNetworkBlocker,
+  type NetworkBlockerConfig,
   type Regulation,
   resolveTranslations,
   type ScriptEntry,
@@ -18,7 +19,13 @@ import {
 } from "@cookieyes/core";
 import { injectStyles } from "./styles/inject.js";
 
-export type RuntimeMode = "offline" | "self-hosted";
+/**
+ * @deprecated Use `"cookie-only"` instead — identical behavior, clearer name.
+ * `"offline"` still works but will be removed in a future release.
+ */
+type DeprecatedOfflineMode = "offline";
+
+export type RuntimeMode = "cookie-only" | "self-hosted" | DeprecatedOfflineMode;
 export type ColorSchemePref = "light" | "dark" | "system";
 
 type RuntimeConfig = {
@@ -115,9 +122,10 @@ function mountRuntime(cfg: RuntimeConfig): CookieYesRuntime {
   if (!cfg.mode) {
     throw new Error(
       "createCookieYes(): .mode() is required before .mount(). " +
-        "Call .mode('offline') or .mode('self-hosted').",
+        "Call .mode('cookie-only') or .mode('self-hosted').",
     );
   }
+  if (cfg.mode === "offline") _warnOfflineModeDeprecated();
   if (cfg.mode === "self-hosted" && !cfg.backend && !cfg.backendURL) {
     throw new Error(
       "createCookieYes(): .mode('self-hosted') requires either .backend(...) or .backendURL(...).",

--- a/sdk/translations/README.md
+++ b/sdk/translations/README.md
@@ -20,7 +20,7 @@ import { fr } from "@cookieyes/translations/fr";
 // Pass into the SDK as the translation map, e.g. with the builder:
 //   createCookieYes().i18n({ messages: { en, fr } }).mount();
 // or with the core runtime:
-//   getOrCreateConsentRuntime({ mode: "offline", i18n: { messages: { en, fr } } });
+//   getOrCreateConsentRuntime({ mode: "cookie-only", i18n: { messages: { en, fr } } });
 ```
 
 Available sub-paths: `./en`, `./es`, `./fr`, `./de`, `./it`. The package root


### PR DESCRIPTION
## Summary

`mode: "offline"` is a confusing name — it sounds like "works without internet" but actually means "consent is stored only in a cookie, with no backend sync." New developers had to have this explained via a parenthetical in the docs, which shouldn't be necessary.

- Added `mode: "cookie-only"` — does exactly what `"offline"` does today, just a clearer name.
- `"offline"` keeps working exactly as before — no breaking change for existing usage.
- Using `"offline"` now logs a one-time console warning pointing to `"cookie-only"`, and shows as deprecated (struck-through) in editor autocomplete.
- `"offline"` will be removed 3 releases from now.
- The CLI now scaffolds new projects with `"cookie-only"` by default.
- Docs and examples across all packages updated to use `"cookie-only"`, with a single deprecation note explaining the old name (not shown as an equal alternative).

## Related issues

N/A

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] Added a changeset (`pnpm changeset`) for any user-facing change
- [x] Updated docs / README where relevant