### PR TITLE
Fix keyboard/focus-management and screen-reader gaps in banner and dialogs

### DIFF
--- a/.changeset/accessibility-baseline.md
+++ b/.changeset/accessibility-baseline.md
@@ -1,0 +1,34 @@
+---
+"@cookieyes/react": patch
+---
+
+Fix keyboard/focus-management and screen-reader gaps in `<CookieBanner />`,
+`<CookiePreferences />`, and `<CookieOptOut />`:
+
+- Opening `<CookiePreferences />` or `<CookieOptOut />` now moves focus into
+  the dialog automatically; closing it (Save, Cancel, or `Esc`) now returns
+  focus to whichever control opened it — including when that control was the
+  banner or the recall button, both of which remount when the dialog closes.
+- The Preferences category toggles (`role="switch"`) now have a real
+  accessible name — previously an `aria-label`-less switch, announced by
+  screen readers with no indication of which category it controlled.
+- The banner is now announced by screen readers when it first appears, via
+  an `aria-live="assertive"` announcer that's rendered independently of the
+  banner's own mount/hide cycle and populated after a short delay rather
+  than immediately — a live-region update fired right at page-load time
+  commonly gets dropped while the screen reader is still announcing the
+  navigation itself.
+- The banner now portals to the front of `<body>` once mounted (still
+  server-rendered inline first, so there's no change to first-paint/CLS
+  behavior). Previously it rendered wherever `<CookieYesRoot>` was mounted —
+  after the app's own content, per both the docs and the CLI's scaffold —
+  which put it last in the page's reading order. A screen-reader or
+  keyboard user couldn't reach it without stepping through the entire page
+  first; now it's reachable within the first Tab/swipe.
+- All entrance/exit animations (banner, dialogs, recall button) now respect
+  `prefers-reduced-motion: reduce` — same end state, no motion.
+- Adds automated `axe-core` accessibility tests for the banner and both
+  dialogs, and documents the keyboard/focus contract and a scoped
+  accessibility posture statement in the README.
+
+No public API changes — this is behavior/bug fixes to existing components.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.7
         version: 4.1.8(vitest@4.1.8)
+      axe-core:
+        specifier: ^4.12.1
+        version: 4.12.1
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -1223,6 +1226,10 @@ packages:
 
   ast-v8-to-istanbul@1.0.3:
     resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
 
   baseline-browser-mapping@2.10.33:
     resolution: {integrity: sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==}
@@ -3034,6 +3041,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  axe-core@4.12.1: {}
 
   baseline-browser-mapping@2.10.33: {}
 

--- a/sdk/react/README.md
+++ b/sdk/react/README.md
@@ -127,6 +127,55 @@ major-version bump and a regression test:
 | `.cy-banner` | The visible banner card (same element as above). Its bounding box equals what the user sees. |
 | `.cy-banner-wrap` | A logical grouping wrapper rendered with `display: contents` — it generates **no box** and is never the measured element. |
 
+## Accessibility
+
+**Scope of this section:** keyboard operability, focus management, screen-reader
+labelling, and reduced motion for `<CookieBanner />`, `<CookiePreferences />`,
+`<CookieOptOut />`, and `<RecallButton />`. This is **not** a "WCAG 2.1 AA
+compliant" claim — things outside this scope (color contrast, text resizing,
+and anything in your own custom theme/content) aren't covered and shouldn't be
+assumed to be.
+
+### Keyboard behavior
+
+If you're building a custom UI on the headless primitives (`Banner`,
+`Preferences`, `OptOut`), this is the behavior to preserve:
+
+- **Tab order** follows DOM order in every preset — e.g. Preferences goes
+  Close → category toggles → Reject All → Save → Accept All → branding link.
+  The banner is **not modal**, so Tab can leave it into the rest of your page;
+  `<CookiePreferences />` and `<CookieOptOut />` **are** modal and trap focus.
+- **`Esc`** closes `<CookiePreferences />` and `<CookieOptOut />`.
+- **Focus trap**: while a dialog is open, `Tab` / `Shift+Tab` cycle only
+  through its own controls.
+- **Focus management on open/close**: opening a dialog moves focus into it
+  (onto the dialog element itself, which carries its `aria-label`); closing it
+  — via Save, Cancel, or `Esc` — returns focus to whatever control opened it.
+- **Visible focus indicator**: every interactive control has a `:focus-visible`
+  outline; none of this relies on the browser's default styling.
+
+### Reduced motion
+
+All entrance/exit animations (banner slide-in, dialog fade/slide, the recall
+button's pop-in) are removed under `prefers-reduced-motion: reduce` — every
+element still appears and works identically, just without motion.
+
+### Automated testing
+
+`axe-core` runs against `<CookieBanner />`, `<CookiePreferences />`, and
+`<CookieOptOut />` in CI (`src/__tests__/a11y.test.tsx`) and fails the build on
+any violation. **Caveat:** this runs under jsdom, not a real browser — it
+catches structural/ARIA regressions (missing accessible names, wrong roles,
+broken labelling) but can't evaluate layout- or paint-dependent rules like
+color contrast. It's a regression net, not a substitute for manual testing.
+
+### Manual testing
+
+Keyboard and focus-management behavior above was verified by hand across
+desktop/tablet/mobile viewports and light/dark color schemes, and the
+labelling behavior was verified with VoiceOver. If you find something that
+doesn't sound right with your own screen reader, please open an issue.
+
 ## Hooks
 
 ```tsx

--- a/sdk/react/package.json
+++ b/sdk/react/package.json
@@ -71,6 +71,7 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitest/coverage-v8": "^4.1.7",
+    "axe-core": "^4.12.1",
     "jsdom": "^29.1.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/sdk/react/src/__tests__/CookieBanner.test.tsx
+++ b/sdk/react/src/__tests__/CookieBanner.test.tsx
@@ -13,7 +13,11 @@ describe("CookieBanner — GDPR", () => {
   it("renders the title and the opt-in actions", () => {
     mountOffline("GDPR");
     render(<CookieBanner />);
-    expect(screen.getByText("We value your privacy")).toBeTruthy();
+    // The title also appears in a visually-hidden live-region announcer
+    // (for screen readers on first appearance) — scope to the visible title.
+    expect(
+      screen.getByText("We value your privacy", { selector: ".cy-banner-title" }),
+    ).toBeTruthy();
     expect(screen.getByText("Accept All")).toBeTruthy();
     expect(screen.getByText("Reject All")).toBeTruthy();
     expect(screen.getByText("Customise")).toBeTruthy();
@@ -39,6 +43,27 @@ describe("CookieBanner — GDPR", () => {
     render(<CookieBanner />);
     fireEvent.click(screen.getByText("Customise"));
     expect(rt.getSnapshot().isPreferencesOpen).toBe(true);
+  });
+});
+
+describe("CookieBanner — DOM placement", () => {
+  it("portals to the front of <body>, regardless of where it's rendered", () => {
+    mountOffline("GDPR");
+    // Render into a wrapper that's itself appended to <body>, simulating
+    // <CookieYesRoot> mounting after the app's own content — the exact case
+    // that made the banner unreachable without the portal.
+    const appContent = document.createElement("div");
+    appContent.id = "app-content-stand-in";
+    document.body.appendChild(appContent);
+    render(<CookieBanner />, { container: appContent });
+
+    const portalRoot = document.getElementById("cookieyes-portal-root");
+    expect(portalRoot).toBeTruthy();
+    expect(document.body.firstElementChild).toBe(portalRoot);
+    expect(portalRoot?.querySelector("[data-cky-banner]")).toBeTruthy();
+    expect(appContent.querySelector("[data-cky-banner]")).toBeNull();
+
+    document.body.removeChild(appContent);
   });
 });
 

--- a/sdk/react/src/__tests__/a11y.test.tsx
+++ b/sdk/react/src/__tests__/a11y.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render } from "@testing-library/react";
+import axe from "axe-core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CookieBanner } from "../presets/CookieBanner.js";
+import { CookieOptOut } from "../presets/CookieOptOut.js";
+import { CookiePreferences } from "../presets/CookiePreferences.js";
+import { clearCookie, mountOffline, teardown } from "./test-utils.js";
+
+/**
+ * Runs axe-core against a rendered container and asserts zero violations.
+ *
+ * Caveat: axe-core runs here under jsdom, not a real browser. Layout- and
+ * paint-dependent rules (color contrast, visible text sizing, etc.) can't be
+ * evaluated in jsdom and are skipped — this catches structural/ARIA
+ * regressions (missing names, wrong roles, broken labelling), not the full
+ * WCAG surface. See docs/accessibility.md for what this does and doesn't cover.
+ */
+async function expectNoViolations(container: Element): Promise<void> {
+  const results = await axe.run(container);
+  const summary = results.violations
+    .map((v) => `${v.id}: ${v.description} (${v.nodes.length} node(s))`)
+    .join("\n");
+  expect(results.violations, summary).toHaveLength(0);
+}
+
+beforeEach(clearCookie);
+afterEach(() => {
+  cleanup();
+  teardown();
+});
+
+describe("accessibility — automated (axe-core, jsdom-scoped)", () => {
+  it("banner has no axe violations (GDPR)", async () => {
+    mountOffline("GDPR");
+    const { container } = render(<CookieBanner />);
+    await expectNoViolations(container);
+  });
+
+  it("banner has no axe violations (CCPA)", async () => {
+    mountOffline("CCPA");
+    const { container } = render(<CookieBanner />);
+    await expectNoViolations(container);
+  });
+
+  it("preferences dialog has no axe violations when open", async () => {
+    const rt = mountOffline("GDPR");
+    rt.manager.showPreferences();
+    const { container } = render(<CookiePreferences />);
+    await expectNoViolations(container);
+  });
+
+  it("opt-out dialog has no axe violations when open", async () => {
+    const rt = mountOffline("CCPA");
+    rt.showOptOut();
+    const { container } = render(<CookieOptOut />);
+    await expectNoViolations(container);
+  });
+});

--- a/sdk/react/src/controls/RecallButton.tsx
+++ b/sdk/react/src/controls/RecallButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type ComponentPropsWithoutRef, forwardRef, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { RevisitIcon } from "../components/icons.js";
 import { useBannerVisibility } from "../hooks/useBannerVisibility.js";
 import { useConsent } from "../hooks/useConsent.js";
@@ -8,7 +9,7 @@ import { useConsentActions } from "../hooks/useConsentActions.js";
 import { useOptOutOpen } from "../hooks/useOptOutOpen.js";
 import { usePreferencesOpen } from "../hooks/usePreferencesOpen.js";
 import { useRegulation } from "../hooks/useRegulation.js";
-import { chain } from "../primitives/utils.js";
+import { chain, useBodyPortalRoot } from "../primitives/utils.js";
 
 type Props = ComponentPropsWithoutRef<"button"> & { children?: ReactNode };
 
@@ -22,6 +23,7 @@ export const RecallButton = forwardRef<HTMLButtonElement, Props>(function Recall
   const optOutOpen = useOptOutOpen();
   const regulation = useRegulation();
   const { showPreferences, showOptOut } = useConsentActions();
+  const portalRoot = useBodyPortalRoot();
 
   if (bannerVisible) return null;
   if (preferencesOpen || optOutOpen) return null;
@@ -29,7 +31,7 @@ export const RecallButton = forwardRef<HTMLButtonElement, Props>(function Recall
 
   const onActivate = regulation === "CCPA" ? showOptOut : showPreferences;
 
-  return (
+  const button = (
     <button
       ref={ref}
       type="button"
@@ -44,4 +46,6 @@ export const RecallButton = forwardRef<HTMLButtonElement, Props>(function Recall
       {children ?? <RevisitIcon />}
     </button>
   );
+
+  return portalRoot ? createPortal(button, portalRoot) : button;
 });

--- a/sdk/react/src/hooks/useConsentActions.ts
+++ b/sdk/react/src/hooks/useConsentActions.ts
@@ -2,6 +2,7 @@
 
 import type { ConsentCategory } from "@cookieyes/core";
 import { useMemo } from "react";
+import { rememberFocusBeforeDialog } from "../primitives/utils.js";
 import { _tryGetCookieYes } from "../runtime.js";
 
 export type ConsentActions = {
@@ -41,9 +42,15 @@ export function useConsentActions(): ConsentActions {
       save: () => runtime.manager.savePreferences(),
       updateCategory: (category, value) => runtime.manager.updateCategory(category, value),
       reset: () => runtime.manager.resetConsent(),
-      showPreferences: () => runtime.manager.showPreferences(),
+      showPreferences: () => {
+        rememberFocusBeforeDialog();
+        runtime.manager.showPreferences();
+      },
       hidePreferences: () => runtime.manager.hidePreferences(),
-      showOptOut: () => runtime.showOptOut(),
+      showOptOut: () => {
+        rememberFocusBeforeDialog();
+        runtime.showOptOut();
+      },
       hideOptOut: () => runtime.hideOptOut(),
     };
   }, [runtime]);

--- a/sdk/react/src/presets/CookieBanner.tsx
+++ b/sdk/react/src/presets/CookieBanner.tsx
@@ -1,50 +1,96 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { useBannerVisibility } from "../hooks/useBannerVisibility.js";
 import { useRegulation } from "../hooks/useRegulation.js";
 import { useTranslations } from "../hooks/useTranslations.js";
 import { Banner } from "../primitives/Banner.js";
+
+const ANNOUNCE_DELAY_MS = 700;
 
 export function CookieBanner() {
   const reg = useRegulation();
   const t = useTranslations();
   const isCCPA = reg === "CCPA";
+  const visible = useBannerVisibility();
+
+  // Rendered outside <Banner.Root> (unconditionally, not tied to the
+  // banner's own mount/hide cycle) and populated after a real delay, not
+  // just React's next tick — both matter:
+  //
+  // - On first page load, this component itself is mounting for the first
+  //   time regardless of where the span lives, so "already in the DOM"
+  //   alone doesn't fix the very first appearance. What actually helps
+  //   there is the delay: screen readers are typically still announcing
+  //   the page navigation itself right after load, and a live-region
+  //   update fired within that window commonly gets dropped rather than
+  //   queued. A few hundred ms of headroom avoids competing with it.
+  // - On later appearances (e.g. after "reset consent" while the banner
+  //   was already hidden), keeping the region outside the conditional
+  //   mount means it's a change to an element the AT has tracked all
+  //   along, not a freshly-inserted one — the reliable case either way.
+  const [announcement, setAnnouncement] = useState("");
+  useEffect(() => {
+    if (!visible) {
+      setAnnouncement("");
+      return;
+    }
+    const id = setTimeout(() => setAnnouncement(t.bannerTitle), ANNOUNCE_DELAY_MS);
+    return () => clearTimeout(id);
+  }, [visible, t.bannerTitle]);
 
   return (
-    <Banner.Root className="cy-banner-wrap" data-cy-theme="system">
-      {/* Canonical banner element: the visible card carries the stable
+    <>
+      {/* A consent prompt is important enough to justify aria-live="assertive"
+          over "polite" — it's more consistently announced by assistive tech. */}
+      <span
+        aria-live="assertive"
+        style={{
+          position: "absolute",
+          width: 1,
+          height: 1,
+          overflow: "hidden",
+          clip: "rect(0,0,0,0)",
+        }}
+      >
+        {announcement}
+      </span>
+      <Banner.Root className="cy-banner-wrap" data-cy-theme="system">
+        {/* Canonical banner element: the visible card carries the stable
           `data-cky-banner` hook + dialog role, and (via `display: contents` on
           the wrapper) is the only measurable banner box. */}
-      <div
-        className="cy-banner"
-        data-cky-banner=""
-        role="dialog"
-        aria-modal="false"
-        aria-live="polite"
-        aria-label={t.bannerTitle}
-      >
-        {isCCPA && <Banner.Close className="cy-banner-close" />}
+        <div
+          className="cy-banner"
+          data-cky-banner=""
+          role="dialog"
+          aria-modal="false"
+          aria-live="polite"
+          aria-label={t.bannerTitle}
+        >
+          {isCCPA && <Banner.Close className="cy-banner-close" />}
 
-        <div className="cy-banner-text">
-          <Banner.Title className="cy-banner-title" />
-          <Banner.Description className="cy-banner-description" />
+          <div className="cy-banner-text">
+            <Banner.Title className="cy-banner-title" />
+            <Banner.Description className="cy-banner-description" />
+          </div>
+
+          <Banner.Actions className="cy-banner-actions">
+            {isCCPA ? (
+              <Banner.DoNotSell className="cy-btn cy-btn-do-not-sell" />
+            ) : (
+              <>
+                <Banner.OpenPreferences className="cy-btn cy-btn-outline" />
+                <Banner.RejectAll className="cy-btn cy-btn-primary" />
+                <Banner.AcceptAll className="cy-btn cy-btn-primary" />
+              </>
+            )}
+          </Banner.Actions>
+
+          <div className={`cy-banner-footer${isCCPA ? " cy-banner-footer--ccpa" : ""}`}>
+            <Banner.Branding className="cy-branding" />
+          </div>
         </div>
-
-        <Banner.Actions className="cy-banner-actions">
-          {isCCPA ? (
-            <Banner.DoNotSell className="cy-btn cy-btn-do-not-sell" />
-          ) : (
-            <>
-              <Banner.OpenPreferences className="cy-btn cy-btn-outline" />
-              <Banner.RejectAll className="cy-btn cy-btn-primary" />
-              <Banner.AcceptAll className="cy-btn cy-btn-primary" />
-            </>
-          )}
-        </Banner.Actions>
-
-        <div className={`cy-banner-footer${isCCPA ? " cy-banner-footer--ccpa" : ""}`}>
-          <Banner.Branding className="cy-branding" />
-        </div>
-      </div>
-    </Banner.Root>
+      </Banner.Root>
+    </>
   );
 }

--- a/sdk/react/src/presets/CookiePreferences.tsx
+++ b/sdk/react/src/presets/CookiePreferences.tsx
@@ -32,6 +32,7 @@ export function CookiePreferences() {
                               role="switch"
                               checked={checked}
                               aria-checked={checked}
+                              aria-label={label}
                               onChange={(e) => toggle(e.target.checked)}
                             />
                             <span className="cy-toggle-track" aria-hidden="true">

--- a/sdk/react/src/primitives/Banner.tsx
+++ b/sdk/react/src/primitives/Banner.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { type ComponentPropsWithoutRef, forwardRef, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { CookieYesLogo } from "../components/icons.js";
 import { useBannerVisibility } from "../hooks/useBannerVisibility.js";
 import { useConsentActions } from "../hooks/useConsentActions.js";
 import { useRegulation } from "../hooks/useRegulation.js";
 import { useTranslations } from "../hooks/useTranslations.js";
-import { chain } from "./utils.js";
+import { chain, useBodyPortalRoot } from "./utils.js";
 
 type DivProps = ComponentPropsWithoutRef<"div">;
 type ButtonProps = ComponentPropsWithoutRef<"button">;
@@ -18,16 +19,21 @@ const Root = forwardRef<HTMLDivElement, DivProps & { children?: ReactNode }>(fun
   ref,
 ) {
   const visible = useBannerVisibility();
+  const portalRoot = useBodyPortalRoot();
+
   if (!visible) return null;
+
   // Neutral grouping element (the preset gives it `display: contents`). The
   // dialog role / aria / canonical `data-cky-banner` live on the visible card
   // so the identified, measurable banner element equals what the user sees.
   // Callers can still pass `role` and other attributes via props.
-  return (
+  const content = (
     <div ref={ref} {...props}>
       {children}
     </div>
   );
+
+  return portalRoot ? createPortal(content, portalRoot) : content;
 });
 
 const Title = forwardRef<HTMLParagraphElement, ParagraphProps>(function BannerTitle(

--- a/sdk/react/src/primitives/OptOut.tsx
+++ b/sdk/react/src/primitives/OptOut.tsx
@@ -15,7 +15,7 @@ import { useConsent } from "../hooks/useConsent.js";
 import { useConsentActions } from "../hooks/useConsentActions.js";
 import { useOptOutOpen } from "../hooks/useOptOutOpen.js";
 import { useTranslations } from "../hooks/useTranslations.js";
-import { chain, useEscapeKey, useFocusTrap } from "./utils.js";
+import { chain, useAutoFocusDialog, useEscapeKey, useFocusTrap } from "./utils.js";
 
 type DivProps = ComponentPropsWithoutRef<"div">;
 type ButtonProps = ComponentPropsWithoutRef<"button">;
@@ -60,6 +60,7 @@ const Root = forwardRef<HTMLDivElement, DivProps & { children?: ReactNode }>(fun
 
   useEscapeKey(open, hideOptOut);
   useFocusTrap(open, containerRef);
+  useAutoFocusDialog(open, containerRef);
 
   useEffect(() => {
     if (open) {
@@ -99,6 +100,7 @@ const Root = forwardRef<HTMLDivElement, DivProps & { children?: ReactNode }>(fun
         role="dialog"
         aria-modal="true"
         aria-label="Opt-out preferences"
+        tabIndex={-1}
         {...props}
       >
         {children}

--- a/sdk/react/src/primitives/Preferences.tsx
+++ b/sdk/react/src/primitives/Preferences.tsx
@@ -14,7 +14,7 @@ import { useConsent } from "../hooks/useConsent.js";
 import { useConsentActions } from "../hooks/useConsentActions.js";
 import { usePreferencesOpen } from "../hooks/usePreferencesOpen.js";
 import { useTranslations } from "../hooks/useTranslations.js";
-import { chain, useEscapeKey, useFocusTrap } from "./utils.js";
+import { chain, useAutoFocusDialog, useEscapeKey, useFocusTrap } from "./utils.js";
 
 type DivProps = ComponentPropsWithoutRef<"div">;
 type ButtonProps = ComponentPropsWithoutRef<"button">;
@@ -54,6 +54,7 @@ const Root = forwardRef<HTMLDivElement, DivProps & { children?: ReactNode }>(
 
     useEscapeKey(open, hidePreferences);
     useFocusTrap(open, containerRef);
+    useAutoFocusDialog(open, containerRef);
 
     if (!open) return null;
 
@@ -68,6 +69,7 @@ const Root = forwardRef<HTMLDivElement, DivProps & { children?: ReactNode }>(
           role="dialog"
           aria-modal="true"
           aria-label="Cookie preferences"
+          tabIndex={-1}
           {...props}
         >
           {children}

--- a/sdk/react/src/primitives/utils.ts
+++ b/sdk/react/src/primitives/utils.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { type RefObject, type SyntheticEvent, useEffect } from "react";
+import { type RefObject, type SyntheticEvent, useEffect, useState } from "react";
 
 export function chain<E extends SyntheticEvent>(
   userHandler: ((e: E) => void) | undefined,
@@ -21,6 +21,108 @@ export function useEscapeKey(enabled: boolean, onEscape: () => void): void {
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [enabled, onEscape]);
+}
+
+// Set by rememberFocusBeforeDialog() at the moment an opening action fires —
+// deliberately *not* captured inside the dialog's own mount effect, because
+// opening a dialog also hides the banner in the same render. By the time an
+// effect runs, the button that triggered the open may already be gone from
+// the DOM (and the browser will have defaulted focus to <body>), so we'd be
+// "remembering" the wrong element. Capturing it synchronously in the click
+// handler, before that re-render happens, is the only reliable point.
+let lastFocusedBeforeDialog: HTMLElement | null = null;
+// Text/aria-label snapshot of the opener, captured alongside the reference —
+// used to re-find its replacement by identity if the original node doesn't
+// survive the remount (see useAutoFocusDialog's cleanup).
+let lastFocusedIdentity: string | null = null;
+
+function identityOf(el: HTMLElement | null): string | null {
+  if (!el) return null;
+  const text = (el.getAttribute("aria-label") || el.textContent || "").trim();
+  return text.length > 0 ? text : null;
+}
+
+/**
+ * Call this synchronously inside an action that's about to open a dialog
+ * (e.g. `showPreferences`, `showOptOut`), before it triggers the state
+ * change — see {@link useAutoFocusDialog}.
+ */
+export function rememberFocusBeforeDialog(): void {
+  const el = document.activeElement as HTMLElement | null;
+  lastFocusedBeforeDialog = el;
+  lastFocusedIdentity = identityOf(el);
+}
+
+/**
+ * On open: moves focus into the dialog container (so screen readers announce
+ * its `aria-label` instead of falling back to page-level context). On close:
+ * returns focus to whatever was remembered via {@link rememberFocusBeforeDialog},
+ * so the visitor lands back exactly where they were.
+ *
+ * The container must be focusable (`tabIndex={-1}`) for this to work — it
+ * isn't a real tab stop, just a programmatic focus target.
+ */
+export function useAutoFocusDialog(
+  open: boolean,
+  containerRef: RefObject<HTMLElement | null>,
+): void {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: containerRef is a stable ref object; re-running this effect on every render of the caller would refocus the dialog each time.
+  useEffect(() => {
+    if (!open) return;
+    containerRef.current?.focus();
+
+    return () => {
+      const opener = lastFocusedBeforeDialog;
+      const identity = lastFocusedIdentity;
+      lastFocusedBeforeDialog = null;
+      lastFocusedIdentity = null;
+
+      // The opener itself can unmount while its dialog is open (the banner
+      // and RecallButton both hide while Preferences/OptOut is open, and
+      // remount as a *new* DOM node when it closes) — a stale reference is
+      // simply disconnected, `.focus()` on it is a silent no-op. Prefer the
+      // real opener if it survived; otherwise re-find its replacement by the
+      // same rendered text/aria-label, so "Do Not Sell" reliably lands back
+      // on "Do Not Sell" and not just whichever control happens to be first.
+      if (opener?.isConnected) {
+        opener.focus();
+        return;
+      }
+      const candidates = document.querySelectorAll<HTMLElement>(
+        "[data-cky-banner] button, [data-cky-banner] a, .cy-widget",
+      );
+      const match = identity
+        ? Array.from(candidates).find((el) => identityOf(el) === identity)
+        : undefined;
+      (match ?? candidates[0])?.focus();
+    };
+  }, [open]);
+}
+
+// Shared by anything that needs to be reachable within the first Tab/swipe
+// rather than wherever <CookieYesRoot> happens to mount (after the app's own
+// content, per the docs and CLI scaffold) — currently the banner and the
+// recall button. Renders inline on the server and on the client's first pass
+// (matching, so hydration doesn't mismatch), then relocates once mounted.
+// `useEffect` never runs during server rendering, so this can't affect the
+// "present in the initial HTML" guarantee.
+const BODY_PORTAL_ROOT_ID = "cookieyes-portal-root";
+
+function getOrCreateBodyPortalRoot(): HTMLElement {
+  const existing = document.getElementById(BODY_PORTAL_ROOT_ID);
+  if (existing) return existing;
+  const el = document.createElement("div");
+  el.id = BODY_PORTAL_ROOT_ID;
+  document.body.insertBefore(el, document.body.firstChild);
+  return el;
+}
+
+export function useBodyPortalRoot(): HTMLElement | null {
+  const [root, setRoot] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setRoot(getOrCreateBodyPortalRoot());
+  }, []);
+  return root;
 }
 
 export function useFocusTrap(enabled: boolean, containerRef: RefObject<HTMLElement | null>): void {

--- a/sdk/react/src/styles/tokens.ts
+++ b/sdk/react/src/styles/tokens.ts
@@ -810,6 +810,17 @@ ${darkBlock}
   to   { opacity: 1; transform: scale(1); }
 }
 
+/* ── Respect prefers-reduced-motion: same end state, no motion ───── */
+@media (prefers-reduced-motion: reduce) {
+  .cy-banner,
+  .cy-banner[data-leaving],
+  .cy-dialog-overlay,
+  .cy-dialog,
+  .cy-widget {
+    animation: none;
+  }
+}
+
 /* ── ConsentFrame placeholder ────────────────────────────────────── */
 .cy-frame-placeholder {
   background: var(--cy-bg);


### PR DESCRIPTION
## Summary
- Move focus into `CookiePreferences`/`CookieOptOut` on open, and return it to the control that opened it on close — including when that control (banner button or recall button) remounts as a new DOM node
- Give the preference category toggles a real accessible name (previously an unlabeled switch)
- Announce the banner to screen readers on first appearance via a live region that's decoupled from the banner's own mount/hide cycle and delayed briefly, since an update fired right at page load commonly loses to the navigation announcement
- Portal the banner and recall button to the front of `<body>` so they're reachable within the first Tab/swipe, rather than after the rest of the page's content — no change to first paint, since both still render inline on the server/first client pass
- Respect `prefers-reduced-motion` across the banner, dialogs, and recall button (same end state, no motion)
- Add automated `axe-core` tests for the banner and both dialogs, document the keyboard/focus contract, and add a scoped accessibility posture statement to the README

No public API changes — behavior/bug fixes to existing components only.

## Test plan
- [x] `pnpm lint`, `pnpm --filter @cookieyes/react typecheck`, `pnpm --filter @cookieyes/react build`, `pnpm --filter @cookieyes/react test` (146 tests, all passing)
- [x] Manual keyboard pass: Tab order, focus trap, `Esc`-to-close, visible focus indicator across desktop/tablet/mobile and light/dark
- [x] Manual VoiceOver pass: labeling, banner announcement, focus trap, focus return
- [x] Verified banner/recall-button reachability and SSR/first-paint behavior with Playwright