### PR TITLE
fix(scripts,nextjs): republish with a resolvable core dependency

### DIFF
--- a/sdk/nextjs/CHANGELOG.md
+++ b/sdk/nextjs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @cookieyes/nextjs
 
+## 0.5.1
+
+### Patch Changes
+
+- Repoint at `@cookieyes/scripts@0.1.1`. 0.5.0 depended on `@cookieyes/scripts@0.1.0`,
+  which was published with an unresolvable `workspace:*` dependency — so
+  `npm install @cookieyes/nextjs@0.5.0` failed with `EUNSUPPORTEDPROTOCOL`. No code
+  change in this package.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/sdk/nextjs/package.json
+++ b/sdk/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cookieyes/nextjs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Next.js App Router adapter for the CookieYes consent SDK",
   "keywords": [
     "cookie consent",

--- a/sdk/scripts/CHANGELOG.md
+++ b/sdk/scripts/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @cookieyes/scripts
 
+## 0.1.1
+
+### Patch Changes
+
+- Fix an unusable `@cookieyes/core` dependency. 0.0.0 and 0.1.0 were published with
+  `"@cookieyes/core": "workspace:*"` — pnpm's workspace protocol, which npm and yarn
+  cannot resolve, so installing this package failed with `EUNSUPPORTEDPROTOCOL`. Both
+  are deprecated; use 0.1.1 or later.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/sdk/scripts/package.json
+++ b/sdk/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cookieyes/scripts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Ready-made, consent-gated third-party integrations for CookieYes (Segment, Google, Meta, and more)",
   "keywords": [
     "cookie consent",


### PR DESCRIPTION
@cookieyes/scripts 0.0.0 and 0.1.0 went out with
`"@cookieyes/core": "workspace:*"` still in the manifest. That protocol is pnpm-only — it is normally rewritten to a real range at publish time, but only by `pnpm publish`. These versions were published with plain `npm publish`, which passes it through verbatim, so anyone installing them gets EUNSUPPORTEDPROTOCOL. @cookieyes/nextjs@0.5.0 depends on scripts@0.1.0 and is therefore uninstallable too.

Bumps scripts to 0.1.1 and nextjs to 0.5.1 so both can be republished through pnpm, which resolves the dependency to @cookieyes/core@0.4.0. No source change in either package.

The broken versions are deprecated on the registry.

<!-- Thanks for contributing! Please fill out the sections below. -->

## Description

<!-- What does this PR change, and why? -->

## Related issue

<!-- e.g. Closes #123 -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Chore / refactor (no functional change)

## How was this tested?

- [ ] Unit tests added/updated
- [ ] Tested manually (describe steps below)

## Checklist

- [ ] `pnpm lint` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] `pnpm test` passes
- [ ] I have updated documentation where relevant
- [ ] I have added a changeset (`pnpm changeset`) for any user-facing change
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org) format

## Additional context

<!-- Anything else reviewers should know. -->
