### PR TITLE
fix(matrix): pin @cookieyes/scripts to a local tarball like the rest

### DIFF
--- a/matrix/example-app/package.json
+++ b/matrix/example-app/package.json
@@ -32,7 +32,8 @@
       "@cookieyes/core": "__TARBALL_CORE__",
       "@cookieyes/react": "__TARBALL_REACT__",
       "@cookieyes/nextjs": "__TARBALL_NEXTJS__",
-      "@cookieyes/test": "__TARBALL_TEST__"
+      "@cookieyes/test": "__TARBALL_TEST__",
+      "@cookieyes/scripts": "__TARBALL_SCRIPTS__"
     }
   }
 }

--- a/matrix/scripts/pack-tarballs.mjs
+++ b/matrix/scripts/pack-tarballs.mjs
@@ -30,6 +30,10 @@ const PACKAGES = [
   { name: "@cookieyes/react", dir: join(repoRoot, "sdk", "react") },
   { name: "@cookieyes/nextjs", dir: join(repoRoot, "sdk", "nextjs") },
   { name: "@cookieyes/test", dir: join(repoRoot, "sdk", "test") },
+  // Not imported by the example app, but @cookieyes/nextjs depends on it, so it
+  // must be packed and pinned like the rest — otherwise pnpm resolves that one
+  // nested dependency from the registry (see scaffold-example-app.mjs's header).
+  { name: "@cookieyes/scripts", dir: join(repoRoot, "sdk", "scripts") },
 ];
 
 function parseArgs(argv) {

--- a/matrix/scripts/scaffold-example-app.mjs
+++ b/matrix/scripts/scaffold-example-app.mjs
@@ -57,6 +57,7 @@ export function renderPackageJson(packageJsonText, { tarballs, versions }) {
     __TARBALL_REACT__: `file:${tarballs["@cookieyes/react"]}`,
     __TARBALL_CORE__: `file:${tarballs["@cookieyes/core"]}`,
     __TARBALL_TEST__: `file:${tarballs["@cookieyes/test"]}`,
+    __TARBALL_SCRIPTS__: `file:${tarballs["@cookieyes/scripts"]}`,
     __NEXT_VERSION__: versions.next,
     __REACT_VERSION__: versions.react,
     __REACT_DOM_VERSION__: versions.reactDom,


### PR DESCRIPTION
Fixes the failing `next-16.3.0-react-19.2.8` leg on #55 (Version Packages).

## Why it failed

The matrix packs and pins four packages — `core`, `react`, `nextjs`, `test` — but `@cookieyes/nextjs` also depends on `@cookieyes/scripts`. That nested dependency was never pinned, so pnpm resolved it from the **public registry** instead of the build under test.

`pnpm pack` turns `workspace:*` into a concrete version, so packed `@cookieyes/nextjs@0.5.2` asks for `@cookieyes/scripts@0.2.0` — which isn't published (npm has `0.0.0`, `0.1.0`, `0.1.1`):

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @cookieyes/scripts@0.2.0
  while fetching it from https://registry.npmjs.org/
This error happened while installing the dependencies of @cookieyes/nextjs@0.5.2
```

## The part worth noting

The version bump didn't introduce this — it exposed it. Every green matrix run so far was quietly testing the **published** `@cookieyes/scripts@0.1.1` next to the local `core`/`react`/`nextjs`. It only ever passed because that version happened to exist. This is exactly the false pass `scaffold-example-app.mjs`'s header comment warns about.

## The change

- `pack-tarballs.mjs` — add `@cookieyes/scripts` to `PACKAGES` (`TARBALL_PREFIX_TO_PACKAGE` derives from it, so `resolveTarballsFromDir` picks it up)
- `scaffold-example-app.mjs` — wire the `__TARBALL_SCRIPTS__` replacement
- `example-app/package.json` — pin it in `pnpm.overrides`

It stays out of `dependencies` because the example app never imports it; it only needs pinning wherever it appears in the graph.

## Verification

Reproduced the failure locally by applying the Version PR's versions (`core 0.5.0`, `react 0.6.0`, `nextjs 0.5.2`, `scripts 0.2.0` — three unpublished), then:

- leg passes all six steps: install, typePackageCheck, typecheck, build, ssrRender (3 assertions), jsdomBehaviour (2 tests)
- the scratch install resolves `@cookieyes+scripts@file+...` at `0.2.0`, proving it came from the tarball, not the registry
- re-verified green at the current (unbumped) versions
- harness tests 9/9, `derive-check` OK, lint clean

No changeset — the matrix harness isn't published.

> [!IMPORTANT]
> Merge this before #55. Merging #55 publishes, and the matrix would otherwise be signing off on a `scripts` package it never tested.