### PR TITLE
fix(web): check the size report by fingerprint, not by package version

### DIFF
--- a/apps/web/scripts/generate-bundle-size.mjs
+++ b/apps/web/scripts/generate-bundle-size.mjs
@@ -13,8 +13,8 @@
 //
 // Fails closed (exit 1) rather than emitting a plausible-looking wrong number:
 //   1. the report is missing — someone needs to run `pnpm size`
-//   2. the report predates the SDK versions in the workspace, so it describes
-//      code that is no longer here
+//   2. the report's fingerprint no longer matches the SDK in the tree, so it
+//      describes code that is no longer here
 //   3. a layer the page renders is absent from the report
 //   4. a competitor figure has no citation, which is what makes the "N× smaller"
 //      claim reproducible rather than an assertion
@@ -22,6 +22,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { sdkFingerprint } from "../../../tools/size/sdk-fingerprint.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const webRoot = join(here, "..");
@@ -44,20 +45,29 @@ if (!existsSync(reportPath)) {
 
 const report = JSON.parse(readFileSync(reportPath, "utf8"));
 
-// The report records the SDK versions it measured. If those have moved on, the
-// figures describe code that is no longer in the tree, and publishing them
-// would recreate the exact problem this generator exists to end.
-for (const [name, measuredVersion] of Object.entries(report.versions ?? {})) {
-  const dir = name.replace("@cookieyes/", "");
-  const manifestPath = join(repoRoot, "sdk", dir, "package.json");
-  if (!existsSync(manifestPath)) continue;
-  const current = JSON.parse(readFileSync(manifestPath, "utf8")).version;
-  if (current !== measuredVersion) {
-    fail(
-      `the measurement describes ${name}@${measuredVersion} but the workspace has ` +
-        `${current}.\n  Re-run \`pnpm size\` and commit the updated report.`,
-    );
-  }
+// Does this measurement still describe the code in this tree? The report carries
+// a fingerprint of everything that determines the figures; if the SDK has moved
+// on, publishing them would recreate the exact problem this generator exists to
+// end.
+//
+// This compares the fingerprint and NOT the package versions. Comparing versions
+// is wrong in both directions: it fails the changesets release PR, which bumps
+// versions and touches no code, and it passes an ordinary pull request that
+// changes code without touching a version. The first of those blocked a release.
+const currentFingerprint = sdkFingerprint();
+if (report.sdkFingerprint && report.sdkFingerprint !== currentFingerprint) {
+  fail(
+    `the measurement describes a different SDK than the one in this tree.\n` +
+      `  report fingerprint:  ${report.sdkFingerprint}\n` +
+      `  workspace:           ${currentFingerprint}\n` +
+      `  Run \`pnpm size\` from the repo root and commit the updated report.`,
+  );
+}
+if (!report.sdkFingerprint) {
+  fail(
+    "the report has no `sdkFingerprint`, so it cannot be checked against this tree.\n" +
+      "  Run `pnpm size` from the repo root and commit the updated report.",
+  );
 }
 
 /**

--- a/tools/size/README.md
+++ b/tools/size/README.md
@@ -152,6 +152,13 @@ is not a code change, but it is why the budgets carry headroom rather than
 sitting on the measured value, and why a diff of ±a few bytes after a release
 needs no investigation.
 
+This is also why the docs site's staleness check compares a **fingerprint of the
+SDK's bundle inputs** (`sdk-fingerprint.mjs`) and not package versions. A
+version comparison is wrong in both directions: it fails the changesets release
+PR, which bumps versions and touches no code, and it passes an ordinary pull
+request that changes code without touching a version. The first of those blocked
+a release before it was fixed.
+
 ### What is not in the JS delta
 
 The stylesheet. `@cookieyes/react/styles.css` and `critical.css` are measured
@@ -216,3 +223,8 @@ claim. When a release changes it:
 2. Move `previous` in `budgets.json` to the newly published version's numbers.
 3. Anything that quotes a figure reads it from the report — nothing is typed by
    hand in a second place.
+
+You do **not** have to do this to unblock a release. The changesets release PR
+changes only versions and CHANGELOGs, which the fingerprint ignores, so it
+passes on its own. Refreshing the report keeps `previous` meaningful; it is not
+a gate.

--- a/tools/size/measure.mjs
+++ b/tools/size/measure.mjs
@@ -81,6 +81,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { brotliCompressSync, gzipSync, constants as zlibConstants } from "node:zlib";
 import { packTarballs } from "../../matrix/scripts/pack-tarballs.mjs";
+import { sdkFingerprint } from "./sdk-fingerprint.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = resolve(HERE, "..", "..");
@@ -575,6 +576,14 @@ const report = {
   measuredAt: new Date().toISOString(),
   node: process.version,
   versions,
+  /**
+   * Hash of everything that determines these figures — sources, Rollup configs,
+   * bundle-affecting manifest fields. The docs site refuses to publish a figure
+   * whose fingerprint no longer matches the tree. Version numbers are recorded
+   * above for information only; they are pointedly not part of this hash. See
+   * sdk-fingerprint.mjs.
+   */
+  sdkFingerprint: sdkFingerprint(),
   apps: measured,
   deltas,
   interfaceOverCore,

--- a/tools/size/sdk-fingerprint.mjs
+++ b/tools/size/sdk-fingerprint.mjs
@@ -1,0 +1,85 @@
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/** Packages whose code the measurement covers. */
+const PACKAGES = ["core", "react", "nextjs"];
+
+/**
+ * A short hash of everything that determines the measured bundle.
+ *
+ * `size-report.json` records this alongside its figures, and the docs site
+ * refuses to publish a figure whose fingerprint no longer matches the tree. That
+ * is the check that keeps a published size honest: it fails when the code the
+ * number describes has changed, and stays quiet when it hasn't.
+ *
+ * ## What it deliberately leaves out
+ *
+ * **Every package's `version`.** The first version of this guard compared
+ * versions instead, and that is wrong in both directions. It false-positives on
+ * the changesets release PR, which bumps versions and CHANGELOGs and touches no
+ * code at all — the measurement it is guarding is still valid, but the build
+ * fails and the release pipeline stops. It also false-negatives on the case that
+ * actually matters, a code change landing without a version bump, which is
+ * every ordinary pull request.
+ *
+ * **Tests.** They cannot reach a consumer's bundle.
+ *
+ * ## What it covers
+ *
+ * Sources and stylesheets, each package's Rollup config, the shared Rollup
+ * config, and the manifest fields that drive externalisation and tree-shaking
+ * (`exports`, `sideEffects`, `dependencies`, `peerDependencies`). A change to
+ * any of those can move the measured figure; a change to anything else cannot.
+ */
+export function sdkFingerprint() {
+  const files = [];
+
+  const walk = (dir) => {
+    for (const name of readdirSync(dir).sort()) {
+      const full = join(dir, name);
+      if (statSync(full).isDirectory()) {
+        // Tests are not shipped, so they cannot change the figure.
+        if (name !== "__tests__") walk(full);
+      } else if (/\.(ts|tsx|css)$/.test(name) && !/\.test\.tsx?$/.test(name)) {
+        files.push(full);
+      }
+    }
+  };
+
+  for (const pkg of PACKAGES) {
+    const src = join(REPO, "sdk", pkg, "src");
+    if (existsSync(src)) walk(src);
+    const config = join(REPO, "sdk", pkg, "rollup.config.mjs");
+    if (existsSync(config)) files.push(config);
+  }
+  const shared = join(REPO, "rollup.shared.mjs");
+  if (existsSync(shared)) files.push(shared);
+
+  const hash = createHash("sha256");
+  for (const file of files.sort()) {
+    // Hash the path too, so moving a file is a change even if its bytes are not.
+    hash.update(file.slice(REPO.length));
+    hash.update(readFileSync(file));
+  }
+
+  for (const pkg of PACKAGES) {
+    const manifestPath = join(REPO, "sdk", pkg, "package.json");
+    if (!existsSync(manifestPath)) continue;
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    hash.update(
+      JSON.stringify({
+        name: manifest.name,
+        exports: manifest.exports,
+        sideEffects: manifest.sideEffects,
+        dependencies: manifest.dependencies,
+        peerDependencies: manifest.peerDependencies,
+      }),
+    );
+  }
+
+  return hash.digest("hex").slice(0, 16);
+}

--- a/tools/size/size-report.json
+++ b/tools/size/size-report.json
@@ -11,13 +11,14 @@
     "next": "16.3.0",
     "react": "19.2.8"
   },
-  "measuredAt": "2026-09-08T05:20:21.061Z",
+  "measuredAt": "2026-09-08T06:38:50.777Z",
   "node": "v24.6.0",
   "versions": {
     "@cookieyes/core": "0.5.0",
     "@cookieyes/react": "0.6.1",
     "@cookieyes/nextjs": "0.5.3"
   },
+  "sdkFingerprint": "2351146ba55b9d70",
   "apps": {
     "baseline": {
       "label": "empty Next.js app (control)",


### PR DESCRIPTION
Unblocks the release PR (#74), which this guard was failing.

## What broke

#74 is the automated changesets release PR: it bumps versions and CHANGELOGs and touches no code. The staleness guard added in #72 compared the size report's recorded versions against the workspace, saw `@cookieyes/core` go `0.5.0 → 0.6.0`, and failed the web build — stopping the release pipeline over a measurement that was still valid.

```
[generate-bundle-size] the measurement describes @cookieyes/core@0.5.0
  but the workspace has 0.6.0.
```

## Why version comparison was the wrong signal

Wrong in both directions, which is worse than inconvenient:

- **False positive** — the release PR above. It fires on a bot-authored branch where "re-run `pnpm size` and commit" is awkward, and it gates shipping.
- **False negative** — an ordinary PR that changes SDK code without touching a version, i.e. every ordinary PR. The case the guard most needed to catch was the one it was blind to.

## The fix

The report now records a fingerprint of what actually determines the figures: sources and stylesheets, each package's Rollup config, the shared Rollup config, and the manifest fields that drive externalisation and tree-shaking. Versions are recorded for information and excluded from the hash. Tests are excluded — they cannot reach a consumer's bundle.

Verified both directions:

| scenario | result |
|---|---|
| bump core→0.6.0, react→0.7.0, no code change | **passes** |
| append one line to `sdk/core/src/version.ts` | **fails**, printing both fingerprints and the fix |

The other hard failures are unchanged: a missing report, and a layer the page renders being absent from it. A report with no fingerprint also fails, so this cannot be bypassed by committing an old-format report.

Refreshing the report after a release is still worth doing — it keeps `previous` in `budgets.json` meaningful — but it is no longer a gate on shipping one. The README says so where it lists the release steps.

## After merging

Re-run the checks on #74; it should pass without touching that PR.