### PR TITLE
ci(matrix): format the generated results file before opening its PR

### DIFF
--- a/.github/workflows/peer-matrix.yml
+++ b/.github/workflows/peer-matrix.yml
@@ -213,8 +213,35 @@ jobs:
           name: peer-matrix-results
           path: .
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: pnpm
+
+      # Only needed for Biome, so scripts are skipped — same shape as the
+      # derive-check job above.
+      - name: Install root dependencies only (Biome, for the format step)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
       - name: Replace matrix/matrix-results.json
         run: cp matrix-results.aggregated.json matrix/matrix-results.json
+
+      # `aggregate-results.mjs` writes with `JSON.stringify(x, null, 2)`, which
+      # puts every array element on its own line. Biome's formatter collapses
+      # short arrays onto one, so the raw aggregator output does not match the
+      # committed file's formatting and `pnpm lint` fails the pull request this
+      # job opens — on every run, for a file no human wrote.
+      #
+      # Formatting here, with the Biome the repo pins rather than a fetched one,
+      # is what keeps the two in step. Reimplementing Biome's line-collapsing
+      # rules inside the aggregator would be the same fix in a worse place: it
+      # would drift the next time Biome changes its mind.
+      - name: Format it the way the repository expects
+        run: pnpm exec biome format --write matrix/matrix-results.json
 
       - name: Open pull request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
Fixes the `Lint` failure on the peer-matrix bot's pull request (#71), which happens on **every** run.

## Cause

`matrix/scripts/aggregate-results.mjs` serialises with `JSON.stringify(merged, null, 2)`, putting every array element on its own line. Biome's formatter collapses short arrays onto one:

```
     23 │ - ······"packagesUnderTest": [
     24 │ - ········"@cookieyes/react",
     25 │ - ········"@cookieyes/nextjs"
     26 │ - ······],
     21 │ + ······"packagesUnderTest": ["@cookieyes/react", "@cookieyes/nextjs"],
```

`biome check .` covers `.json`, so the `Lint` step fails the PR the `publish-results` job just opened. The copy committed on `main` passes because it was formatted at some point after being generated — the bot's fresh output diverges from it immediately.

## Fix

`publish-results` now formats the file after copying it and before creating the PR, using the Biome the repo pins rather than a fetched one (a different version would reintroduce the same class of disagreement). That job previously had only `checkout`, so it also gains pnpm, Node and a root-only install — the same shape as the `derive-check` job above it.

## Verified

Against #71's actual file:

| step | result |
|---|---|
| `biome check` before the format step | **fails** (reproduces #71) |
| `biome check` after | **passes** |
| `pnpm lint` after | **passes** |
| parsed JSON before vs after | **identical** — whitespace only |

## Alternatives rejected

- **Emit Biome-compatible JSON from the aggregator** — reimplements a formatter's line-collapsing rules in a script; drifts the next time Biome changes.
- **Add the file to Biome's ignore list** — works, but gives up formatting on a file that is committed, reviewed, and drives a published compatibility claim.

## Note on #71 itself

This fixes future runs. #71's existing commit still carries the unformatted file, so it needs either a formatting commit on `peer-matrix/update-results` or a re-run of the matrix workflow once this is merged.